### PR TITLE
Trim trailing dot from domain name

### DIFF
--- a/namecheap_dns_api_hook.sh
+++ b/namecheap_dns_api_hook.sh
@@ -83,8 +83,9 @@ function deploy_challenge {
         TOKEN_VALUE[$count]="${1}"; shift 
         
         SUB[$count]=`sed -E "s/$SLD.$TLD//" <<< "${DOMAIN}"`
+        CHALLENGE_HOSTNAME=`sed -E "s/\.$//" <<< "${SUB[$count]}"`
         
-        POSTDATA=$POSTDATA" --data-urlencode 'hostname$num=_acme-challenge.${SUB[$count]}'"
+        POSTDATA=$POSTDATA" --data-urlencode 'hostname$num=_acme-challenge.${CHALLENGE_HOSTNAME}'"
         POSTDATA=$POSTDATA" --data-urlencode 'recordtype$num=TXT'"
         POSTDATA=$POSTDATA" --data-urlencode 'address$num=${TOKEN_VALUE[$count]}'"
         POSTDATA=$POSTDATA" --data-urlencode 'ttl$num=60'"


### PR DESCRIPTION
We need to trim the trailing dot from the domain name, because otherwise
the namecheap API will respond with an Error #3031510:

  "The hostname cannot end with a period (.)."