### PR TITLE
Implement exit_hook

### DIFF
--- a/namecheap_dns_api_hook.sh
+++ b/namecheap_dns_api_hook.sh
@@ -231,5 +231,9 @@ function unchanged_cert {
     #   The path of the file containing the intermediate certificate(s).
 }
 
+function exit_hook {
+    # This hook is called once at the end
+}
+
 HANDLER=$1; shift; $HANDLER $@
 exit 0


### PR DESCRIPTION
Fix following error:

```bash
/opt/dehydrated/hooks/namecheap_dns_api_hook.sh: line 232: exit_hook: command not found
```