### PR TITLE
Convert GET to POST

### DIFF
--- a/reload_services.sh
+++ b/reload_services.sh
@@ -5,7 +5,7 @@
 
 # Apache
 #echo " + Reloading Apache configuration"
-#systemctl reload httpd.service
+#systemctl reload apache2.service
 
 # Nginx
 #echo " + Reloading Nginx configuration"


### PR DESCRIPTION
- There are some GET requests that pass the API key. This is dangerous because the key could show up in server logs. POST requests don't have this problem, so all requests to the Namecheap API now use POST requests. **(This change improves the security of the script.)**
- The HTTP call to find the server's IP address was changed to an HTTPS call. This change ensures that the server is really communicating with the intended service for finding the IP address of the server. **(This change improves the security of the script.)**
- The DNS address 8.8.8.8 (Google) that was used in the dig command has been replaced to 1.1.1.1 (Cloudflare). **(This change is because Cloudflare's DNS is faster and more private.)**
- The domain used for IP address lookup has been changed from ipinfo.io/ip to ifconfig.co. **(This change is because the code for ifconfig.co can be reviewed on GitHub.)**