### PR TITLE
Force ipv4

### DIFF
--- a/namecheap_dns_api_hook.sh
+++ b/namecheap_dns_api_hook.sh
@@ -111,7 +111,7 @@ function clean_challenge {
     local TLD=`sed -E 's/.*\.([^.]+)/\1/' <<< "${FIRSTDOMAIN}"`
 
     local POSTDATA=" --data-urlencode 'apiuser=$apiusr' --data-urlencode 'apikey=$apikey' --data-urlencode 'username=$apiusr' --data-urlencode 'ClientIp=$cliip' --data-urlencode 'SLD=$SLD' --data-urlencode 'TLD=$TLD'"
-    local HOSTS_URI="'https://api.namecheap.com/xml.response?apiuser=$apiusr&apikey=$apikey&username=$apiusr&Command=namecheap.domains.dns.setHosts&ClientIp=$cliip&SLD=$SLD&TLD=$TLD'"
+    local HOSTS_URI="https://api.namecheap.com/xml.response"
 
     local num=0
 

--- a/namecheap_dns_api_hook.sh
+++ b/namecheap_dns_api_hook.sh
@@ -1,17 +1,18 @@
 #!/usr/bin/env bash
+#set -x
 
 function deploy_challenge {
     local FIRSTDOMAIN="${1}"
     local SLD=`sed -E 's/(.*\.)*([^.]+)\..*/\2/' <<< "${FIRSTDOMAIN}"`
     local TLD=`sed -E 's/.*\.([^.]+)/\1/' <<< "${FIRSTDOMAIN}"`
 
-    local POSTDATA=" --data-urlencode 'apiuser=$apiusr' --data-urlencode 'apikey=$apikey' --data-urlencode 'username=$apiusr' --data-urlencode 'ClientIp=$cliip' --data-urlencode 'SLD=$SLD' --data-urlencode 'TLD=$TLD'"
+    local POSTDATA=" --data-urlencode apiuser=$apiusr --data-urlencode apikey=$apikey --data-urlencode username=$apiusr --data-urlencode ClientIp=$cliip --data-urlencode SLD=$SLD --data-urlencode TLD=$TLD"
     local HOSTS_URI="https://api.namecheap.com/xml.response"
 
     local num=0
 
     # get list of current records for domain
-    local records_list=`$CURL "$HOSTS_URI""$POSTDATA"" --data-urlencode 'Command=namecheap.domains.dns.getHosts'" | sed -En 's/<host (.*)/\1/p'`
+    local records_list=`$CURL $POSTDATA --data-urlencode 'Command=namecheap.domains.dns.getHosts' "$HOSTS_URI" | sed -En 's/<host (.*)/\1/p'`
 
     # create $RECORDS_BACKUP directory if it doesn't yet exist
     mkdir -p $RECORDS_BACKUP
@@ -20,28 +21,28 @@ function deploy_challenge {
     #    Namecheap's setHosts method requires ALL records to be posted.  Therefore, the required information for recreating ALL records
     #    is extracted.  In addition, to protect against unforeseen issues that may cause the setHosts method to err, this information is
     #    stored in the $RECORDS_BACKUP directory allowing easy reference if they need to be restored manually.
-    POSTDATA=$POSTDATA" --data-urlencode 'Command=namecheap.domains.dns.setHosts'"
-    OLDIFS=$IFS
+    POSTDATA=$POSTDATA" --data-urlencode Command=namecheap.domains.dns.setHosts"
+    OLDIFS="$IFS"
     while read -r current_record; do
         ((num++))
         # extract record attributes and create comma-separate string
         record_params=`sed -E 's/^[^"]*"|"[^"]*$//g; s/"[^"]+"/,/g; s/ +/ /g' <<< "$current_record" | tee "${RECORDS_BACKUP}/${FIRSTDOMAIN}_${num}_record.txt"`
         while IFS=, read -r hostid hostname recordtype address mxpref ttl associatedapptitle friendlyname isactive isddnsenabled; do
             if [[ "$recordtype" = "MX" ]]; then
-                POSTDATA=$POSTDATA" --data-urlencode 'hostname$num=$hostname'"
-                POSTDATA=$POSTDATA" --data-urlencode 'recordtype$num=$recordtype'"
-                POSTDATA=$POSTDATA" --data-urlencode 'address$num=$address'"
-                POSTDATA=$POSTDATA" --data-urlencode 'mxpref$num=$mxpref'"
-                POSTDATA=$POSTDATA" --data-urlencode 'ttl$num=$ttl'"
+                POSTDATA=$POSTDATA" --data-urlencode hostname$num=$hostname"
+                POSTDATA=$POSTDATA" --data-urlencode recordtype$num=$recordtype"
+                POSTDATA=$POSTDATA" --data-urlencode address$num=$address"
+                POSTDATA=$POSTDATA" --data-urlencode mxpref$num=$mxpref"
+                POSTDATA=$POSTDATA" --data-urlencode ttl$num=$ttl"
             else
-                POSTDATA=$POSTDATA" --data-urlencode 'hostname$num=$hostname'"
-                POSTDATA=$POSTDATA" --data-urlencode 'recordtype$num=$recordtype'"
-                POSTDATA=$POSTDATA" --data-urlencode 'address$num=$address'"
-                POSTDATA=$POSTDATA" --data-urlencode 'ttl$num=$ttl'"
+                POSTDATA=$POSTDATA" --data-urlencode hostname$num=$hostname"
+                POSTDATA=$POSTDATA" --data-urlencode recordtype$num=$recordtype"
+                POSTDATA=$POSTDATA" --data-urlencode address$num=$address"
+                POSTDATA=$POSTDATA" --data-urlencode ttl$num=$ttl"
             fi
         done <<< "$record_params"
     done <<< "$records_list"
-    IFS=$OLDIFS
+    IFS="$OLDIFS"
 
     # add challenge records to post data
     local count=0
@@ -66,17 +67,17 @@ function deploy_challenge {
         SUB[$count]=`sed -E "s/$SLD.$TLD//" <<< "${DOMAIN}"`
         CHALLENGE_HOSTNAME=`sed -E "s/\.$//" <<< "${SUB[$count]}"`
 
-        POSTDATA=$POSTDATA" --data-urlencode 'hostname$num=_acme-challenge.${CHALLENGE_HOSTNAME}'"
-        POSTDATA=$POSTDATA" --data-urlencode 'recordtype$num=TXT'"
-        POSTDATA=$POSTDATA" --data-urlencode 'address$num=${TOKEN_VALUE[$count]}'"
-        POSTDATA=$POSTDATA" --data-urlencode 'ttl$num=60'"
+        POSTDATA=$POSTDATA" --data-urlencode hostname$num=_acme-challenge.${CHALLENGE_HOSTNAME}"
+        POSTDATA=$POSTDATA" --data-urlencode recordtype$num=TXT"
+        POSTDATA=$POSTDATA" --data-urlencode address$num=${TOKEN_VALUE[$count]}"
+        POSTDATA=$POSTDATA" --data-urlencode ttl$num=60"
 
         ((count++))
     done
     local items=$count
 
-    local command="$CURL --request POST $HOSTS_URI $POSTDATA 2>&1 > /dev/null"
-    eval $command
+    $CURL --request POST  $POSTDATA "$HOSTS_URI" 2>&1 > /dev/null
+    
 
     # wait up to 30 minutes for DNS updates to be provisioned (check at 15 second intervals)
     timer=0
@@ -110,13 +111,13 @@ function clean_challenge {
     local SLD=`sed -E 's/(.*\.)*([^.]+)\..*/\2/' <<< "${FIRSTDOMAIN}"`
     local TLD=`sed -E 's/.*\.([^.]+)/\1/' <<< "${FIRSTDOMAIN}"`
 
-    local POSTDATA=" --data-urlencode 'apiuser=$apiusr' --data-urlencode 'apikey=$apikey' --data-urlencode 'username=$apiusr' --data-urlencode 'ClientIp=$cliip' --data-urlencode 'SLD=$SLD' --data-urlencode 'TLD=$TLD'"
-    local HOSTS_URI="'https://api.namecheap.com/xml.response?apiuser=$apiusr&apikey=$apikey&username=$apiusr&Command=namecheap.domains.dns.setHosts&ClientIp=$cliip&SLD=$SLD&TLD=$TLD'"
+    local POSTDATA=" --data-urlencode apiuser=$apiusr --data-urlencode apikey=$apikey --data-urlencode username=$apiusr --data-urlencode ClientIp=$cliip --data-urlencode SLD=$SLD --data-urlencode TLD=$TLD"
+    local HOSTS_URI="https://api.namecheap.com/xml.response?apiuser=$apiusr&apikey=$apikey&username=$apiusr&Command=namecheap.domains.dns.setHosts&ClientIp=$cliip&SLD=$SLD&TLD=$TLD"
 
     local num=0
 
     # get list of current records for domain
-    local records_list=`$CURL "$HOSTS_URI""$POSTDATA"" --data-urlencode 'Command=namecheap.domains.dns.getHosts'" | sed -En 's/<host (.*)/\1/p'`
+    local records_list=`$CURL $POSTDATA --data-urlencode 'Command=namecheap.domains.dns.getHosts' "$HOSTS_URI" | sed -En 's/<host (.*)/\1/p'`
 
     # remove challenge records from list
     records_list=`sed '/acme-challenge/d' <<< "$records_list"`
@@ -125,31 +126,30 @@ function clean_challenge {
     #    Namecheap's setHosts method requires ALL records to be posted.  Therefore, the required information for recreating ALL records
     #    is extracted.  In addition, to protect against unforeseen issues that may cause the setHosts method to err, this information is
     #    stored in the $RECORDS_BACKUP allowing easy reference if they need to be restored manually.
-    POSTDATA=$POSTDATA" --data-urlencode 'Command=namecheap.domains.dns.setHosts'"
-    OLDIFS=$IFS
+    POSTDATA=$POSTDATA" --data-urlencode Command=namecheap.domains.dns.setHosts"
+    OLDIFS="$IFS"
     while read -r current_record; do
         ((num++))
         # extract record attributes and create comma-separate string
         record_params=`sed -E 's/^[^"]*"|"[^"]*$//g; s/"[^"]+"/,/g; s/ +/ /g' <<< "$current_record" | tee "${RECORDS_BACKUP}/${FIRSTDOMAIN}_${num}_record.txt"`
         while IFS=, read -r hostid hostname recordtype address mxpref ttl associatedapptitle friendlyname isactive isddnsenabled; do
             if [[ "$recordtype" = "MX" ]]; then
-                POSTDATA=$POSTDATA" --data-urlencode 'hostname$num=$hostname'"
-                POSTDATA=$POSTDATA" --data-urlencode 'recordtype$num=$recordtype'"
-                POSTDATA=$POSTDATA" --data-urlencode 'address$num=$address'"
-                POSTDATA=$POSTDATA" --data-urlencode 'mxpref$num=$mxpref'"
-                POSTDATA=$POSTDATA" --data-urlencode 'ttl$num=$ttl'"
+                POSTDATA=$POSTDATA" --data-urlencode hostname$num=$hostname"
+                POSTDATA=$POSTDATA" --data-urlencode recordtype$num=$recordtype"
+                POSTDATA=$POSTDATA" --data-urlencode address$num=$address"
+                POSTDATA=$POSTDATA" --data-urlencode mxpref$num=$mxpref"
+                POSTDATA=$POSTDATA" --data-urlencode ttl$num=$ttl"
             else
-                POSTDATA=$POSTDATA" --data-urlencode 'hostname$num=$hostname'"
-                POSTDATA=$POSTDATA" --data-urlencode 'recordtype$num=$recordtype'"
-                POSTDATA=$POSTDATA" --data-urlencode 'address$num=$address'"
-                POSTDATA=$POSTDATA" --data-urlencode 'ttl$num=$ttl'"
+                POSTDATA=$POSTDATA" --data-urlencode hostname$num=$hostname"
+                POSTDATA=$POSTDATA" --data-urlencode recordtype$num=$recordtype"
+                POSTDATA=$POSTDATA" --data-urlencode address$num=$address"
+                POSTDATA=$POSTDATA" --data-urlencode ttl$num=$ttl"
             fi
         done <<< "$record_params"
     done <<< "$records_list"
-    IFS=$OLDIFS
+    IFS="$OLDIFS"
 
-    local command="$CURL --request POST $HOSTS_URI $POSTDATA 2>&1 > /dev/null"
-    eval $command
+    $CURL --request POST $POSTDATA "$HOSTS_URI" 2>&1 > /dev/null
 }
 
 function deploy_cert {

--- a/namecheap_dns_api_hook.sh
+++ b/namecheap_dns_api_hook.sh
@@ -403,7 +403,7 @@ else
 fi
 
 # get this client's ip address
-cliip=`$CURL -s https://ifconfig.co`
+cliip=`$CURL -s https://v4.ifconfig.co/ip`
 
 HANDLER="$1"; shift
 if [[ "${HANDLER}" =~ ^(deploy_challenge|clean_challenge|deploy_cert|unchanged_cert|invalid_challenge|request_failure|startup_hook|exit_hook)$ ]]; then

--- a/namecheap_dns_api_hook.sh
+++ b/namecheap_dns_api_hook.sh
@@ -111,7 +111,7 @@ function clean_challenge {
     local TLD=`sed -E 's/.*\.([^.]+)/\1/' <<< "${FIRSTDOMAIN}"`
 
     local POSTDATA=" --data-urlencode 'apiuser=$apiusr' --data-urlencode 'apikey=$apikey' --data-urlencode 'username=$apiusr' --data-urlencode 'ClientIp=$cliip' --data-urlencode 'SLD=$SLD' --data-urlencode 'TLD=$TLD'"
-    local HOSTS_URI="https://api.namecheap.com/xml.response"
+    local HOSTS_URI="'https://api.namecheap.com/xml.response?apiuser=$apiusr&apikey=$apikey&username=$apiusr&Command=namecheap.domains.dns.setHosts&ClientIp=$cliip&SLD=$SLD&TLD=$TLD'"
 
     local num=0
 


### PR DESCRIPTION
Namecheap only allows you to whitelist ipv4 addresses. If you have ipv6 and ipv4 addresses on the server, the ipv6 address might be sent which will be denied by namecheap API.