### PR TITLE
Force ipv4

### DIFF
--- a/namecheap_dns_api_hook.sh
+++ b/namecheap_dns_api_hook.sh
@@ -403,7 +403,7 @@ else
 fi
 
 # get this client's ip address
-cliip=`$CURL -s https://ifconfig.co`
+cliip=`$CURL -s https://v4.ifconfig.co/ip`
 
 HANDLER="$1"; shift
 if [[ "${HANDLER}" =~ ^(deploy_challenge|clean_challenge|deploy_cert|unchanged_cert|invalid_challenge|request_failure|startup_hook|exit_hook)$ ]]; then


### PR DESCRIPTION
Namecheap only allows you to whitelist ipv4 addresses. If you have ipv6 and ipv4 addresses on the server, the ipv6 address might be sent which will be denied by namecheap API.