### PR TITLE
Pass domain, keyfile etc. to reload_services.sh

### DIFF
--- a/namecheap_dns_api_hook.sh
+++ b/namecheap_dns_api_hook.sh
@@ -191,7 +191,7 @@ function deploy_cert {
 
     # reload services
     echo " + Reloading Services"
-    "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/reload_services.sh"
+    "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/reload_services.sh" "$@"
 
     # send email notification
     send_notification $DOMAIN

--- a/reload_services.sh
+++ b/reload_services.sh
@@ -3,6 +3,8 @@
 # Script to reloading services that use SSL certificates to ensure
 # all services are using the latest versions of the certificates.
 
+DOMAIN="${1}" KEYFILE="${2}" CERTFILE="${3}" FULLCHAINFILE="${4}" CHAINFILE="${5}" TIMESTAMP="${6}"
+
 # Apache
 #echo " + Reloading Apache configuration"
 #systemctl reload apache2.service
@@ -10,3 +12,9 @@
 # Nginx
 #echo " + Reloading Nginx configuration"
 #systemctl reload nginx.service
+
+# cPanel
+#function urlencode() {
+#   cat "$1" | perl -MURI::Escape -ne 'print uri_escape($_)'
+#}
+#uapi SSL install_ssl "domain=$DOMAIN" "cert=$(urlencode "$CERTFILE")" "key=$(urlencode "$KEYFILE")"


### PR DESCRIPTION
Pass parameters of `deploy_cert()` to `reload_services.sh`. With this change the user can determine which domains are affected and trigger the required services only.
