### PR TITLE
Curl opts

### DIFF
--- a/config
+++ b/config
@@ -12,6 +12,9 @@
 # Debugging (yes/no)
 #DEBUG=no
 
+# Extra options passed to the curl binary (default: <unset>)
+#CURL_OPTS=
+
 # Records backup locaiton
 #RECORDS_BACKUP=${BASEDIR}/records_backup
 

--- a/namecheap_dns_api_hook.sh
+++ b/namecheap_dns_api_hook.sh
@@ -395,10 +395,9 @@ IFS='
 # load config values
 load_config
 
+CURL="curl ${CURL_OPTS} -s"
 if [[ "${DEBUG}" == "yes" ]]; then
-    CURL="/usr/bin/curl -sv"
-else
-    CURL="/usr/bin/curl -s"
+    CURL="$CURL -v"
 fi
 
 # get this client's ip address

--- a/namecheap_dns_api_hook.sh
+++ b/namecheap_dns_api_hook.sh
@@ -268,6 +268,7 @@ function load_config() {
     apiusr=
     apikey=
     DEBUG=no
+    CURL_OPTS=
     RECORDS_BACKUP=${BASEDIR}/records_backup
     SENDER="sender@example.com"
     RECIPIENT="recipient@example.com"


### PR DESCRIPTION
Allow users to specify additional arguments for every curl calls.
For instance it makes possible to issue curl requests from a specific interface which is whitelisted on namecheap.

- Use `CURL_OPTS` config/environment variable just like in [dehydrtated](https://github.com/lukas2511/dehydrated/blob/master/docs/examples/config#L75)
- Use `curl` from `PATH`, you can be sure `curl` is available because dehydrated uses it already
