### PR TITLE
Update cliip variable as v4.ifconfig.co no longer resolves

### DIFF
--- a/namecheap_dns_api_hook.sh
+++ b/namecheap_dns_api_hook.sh
@@ -478,10 +478,10 @@ if [[ "${DEBUG}" == "yes" ]]; then
 fi
 
 # get this client's ip address
-cliip=`$CURL -s https://v4.ifconfig.co/ip`
+cliip=`$CURL -s https://icanhazip.com`
 while ! valid_ip $cliip; do
   sleep 2
-  cliip=`$CURL -s https://v4.ifconfig.co/ip`
+  cliip=`$CURL -s https://icanhazip.com`
 done
 
 HANDLER="$1"; shift


### PR DESCRIPTION
It looks like v4.ifconfig.co stopped resolving around Nov 16th 2022 based on my logs. This fix should allow the hook to continue working.
Signed-off-by: Jordan Conway <jordan@jordanconway.com>